### PR TITLE
Added `from` command to quote msg from other channels

### DIFF
--- a/cogs/quote.py
+++ b/cogs/quote.py
@@ -79,6 +79,20 @@ class Quote:
             await ctx.message.delete()
         except:
             pass
+        
+    @commands.command(name='from')
+    async def id_command(self, ctx, *, channel: discord.TextChannel, *, message_id):
+        """Quote a message from a specific channel with a specific Message ID in the current channel"""
+        try:
+            message = await channel.get_message(int(message_id))
+            await self.quote_message(message, requestor=ctx.channel.guild.get_member(ctx.author.id))
+        except Exception as e:
+            self.bot.log(e)
+            await ctx.send("I couldn't find a message with that ID from that channel, sorry :(")
+        try:
+            await ctx.message.delete()
+        except:
+            pass
 
     @commands.command(name='user')
     async def user_command(self, ctx, *, user : discord.Member):


### PR DESCRIPTION
I simply copied the `id` implementation and changed the search channel. I did not test this and I don't know if any other changes could be required.
I don't know exactly what the `*` parameters are meant to be, I assumed they were for the spaces? so I added one after the channel to hopefully divide the channel from the messageID.
I highly advise to not merge this PR but only use it as a proof of concept.